### PR TITLE
Replace `=` with `==` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-mpd2=0.5.5
+python-mpd2==0.5.5


### PR DESCRIPTION
    $ sudo pip install -r requirements.txt 
    Invalid requirement: 'python-mpd2=0.5.5'
    = is not a valid operator. Did you mean == ?